### PR TITLE
SR-1702: Fix tag name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ github.event.release.tag_name }}
+          release_name: ${{ github.event.release.tag_name }}
           draft: false
           prerelease: false
     outputs:
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.ARTIFACTORY_DEPLOY_PASSWORD }}
           registry: artifactory.rtr.cloud
           repository: docker/vault-auto-config
-          tags: latest,${{ github.ref }}
+          tags: latest,${{ github.event.release.tag_name }}
 
   upload_assets:
     name: Build and Upload Release Assets


### PR DESCRIPTION
Currently, `github.ref` returns `refs/tags/v0.1.0`, we want just `v0.1.0`