### PR TITLE
SR-1702: Fix tag name again

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,20 @@ on:
     - 'v*' # Version tags, e.g. v1.0.0
 
 jobs:
+  get_version:
+    name: Get Version from Release Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the Version from the Release Tag
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+
   create_release:
     name: Create a Release Version from Tag
     runs-on: ubuntu-latest
+    needs: get_version
     steps:
       - name: Create Release
         id: create_release
@@ -16,8 +27,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.release.tag_name }}
-          release_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ needs.get_version.outputs.version }}
+          release_name: ${{ needs.get_version.outputs.version }}
           draft: false
           prerelease: false
     outputs:
@@ -26,6 +37,7 @@ jobs:
   build_push_docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    needs: get_version
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
@@ -34,7 +46,7 @@ jobs:
           password: ${{ secrets.ARTIFACTORY_DEPLOY_PASSWORD }}
           registry: artifactory.rtr.cloud
           repository: docker/vault-auto-config
-          tags: latest,${{ github.event.release.tag_name }}
+          tags: latest,${{ needs.get_version.outputs.version }}
 
   upload_assets:
     name: Build and Upload Release Assets


### PR DESCRIPTION
I was following erroneous advice from a post 🤦‍♂️ Apparently, this job doesn't have access to the event.  So, trying this method out that was suggested where we do a replace of `/refs/tags` and set it as an output variable to pull in later.