### PR TITLE
SR-1702: Order matters 🤦‍♂️

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
           go-version: 1.14.x
 
       - name: Build Binary ${{ env.BINARY }}
-        run: go build ./cmd/vault-auto-config -o ${{ env.BINARY }}
+        run: go build -o ${{ env.BINARY }} ./cmd/vault-auto-config
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Tagging now works correctly, but, the binary output path has to come before the package being built  