### PR TITLE
Fix approle secret creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ on a need-to-implement basis.  These are the API paths that are configurable via
 
 /v1/auth/approle/role/*
 /v1/auth/approle/role/*/role-id
-/v1/auth/approle/role/*/secret-id
+/v1/auth/approle/role/*/custom-secret-id
 
 /v1/auth/okta/config
 /v1/auth/okta/groups/*

--- a/pkg/vault-auto-config/client/client_vault.go
+++ b/pkg/vault-auto-config/client/client_vault.go
@@ -214,5 +214,10 @@ func (c *VaultClient) Delete(path string, args ...interface{}) error {
 	log.Debugf("Deleting api resource %s", path)
 
 	_, err := c.client.Logical().Delete(path)
+
+	if err != nil {
+		log.Debugf("Deletion failed. Trying again...")
+		_, err = c.client.Logical().Delete(path)
+	}
 	return err
 }

--- a/pkg/vault-auto-config/client/client_vault.go
+++ b/pkg/vault-auto-config/client/client_vault.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 
 	yaml2 "github.com/goccy/go-yaml"
 	"github.com/hashicorp/vault/api"
@@ -21,7 +21,7 @@ var readOnlyPaths = map[string]bool{
 }
 
 var writeOnlyPaths = [...]string{
-	"auth/approle/role/(.*)/secret-id",
+	"auth/approle/role/(.*)/custom-secret-id",
 }
 
 // Creates a new VaultClient

--- a/pkg/vault-auto-config/state/v1/auth/apply_auth_resource.go
+++ b/pkg/vault-auto-config/state/v1/auth/apply_auth_resource.go
@@ -110,5 +110,5 @@ func ApplyAuthApproleRoleIdState(node *config.Node, name string, client client.C
 }
 
 func ApplyAuthApproleSecretIdState(node *config.Node, name string, client client.Client) error {
-	return ApplyAuthSubResourceState(node, name, "role", "secret_id", "secret-id", client)
+	return ApplyAuthSubResourceState(node, name, "role", "secret_id", "custom-secret-id", client)
 }

--- a/pkg/vault-auto-config/state/v1/auth/read_auth_resource.go
+++ b/pkg/vault-auto-config/state/v1/auth/read_auth_resource.go
@@ -84,5 +84,5 @@ func AppendAuthRoleIdState(client client.Client, name string, node *config.Node)
 }
 
 func AppendAuthSecretIdState(client client.Client, name string, node *config.Node) error {
-	return AppendAuthState(client, name, "role", "secret-id", node)
+	return AppendAuthState(client, name, "role", "custom-secret-id", node)
 }

--- a/test/vault-auto-config/vault_auto_config_test.go
+++ b/test/vault-auto-config/vault_auto_config_test.go
@@ -34,7 +34,7 @@ var resources = []string{
 var files = []string{
 	"v1/auth/approle/role/java-app.yaml",
 	"v1/auth/approle/role/java-app/role-id.yaml",
-	"v1/auth/approle/role/java-app/secret-id.yaml",
+	"v1/auth/approle/role/java-app/custom-secret-id.yaml",
 	"v1/auth/kubernetes/role/tech.yaml",
 	"v1/auth/kubernetes/config.yaml",
 	"v1/auth/okta/groups/tech.yaml",


### PR DESCRIPTION
This uses the correct path for creating secrets for `approle` authentication types. Confusingly, the path `/v1/auth/approle/role/*/secret-id` does exists and accepts POST but it ignores the body and creates a random secret_id. `custom-secret-id` does the same but it uses the POST body.

I also made a small adjustment to have the vault client retry a deletion if it fails. I'm seeing deletion timeout sometimes against Kubernetes auth when it is in use so I may experiment more with having additional retrys or lengthening the timeout.