### PR TITLE
Add support for plaintext values

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ vault-auto-config apply --url <vault url> --token <vault token> --input-dir <con
 ```
 
 ##### Secrets
-For the `file-state` and `apply` commands, you can optionally pass a sops encrypted secrets yaml file, which will then
-be used as values in your configuration files.
+For the `file-state` and `apply` commands, you can optionally pass in a values file that will be used to template values in your configuration files.
+
+If your secrets are sops encrypted, you can also pass the encrypted secrets yaml file, which will also be used for templating.
 
 For example:
 
@@ -86,6 +87,11 @@ base_url: okta.com
 Then you could run `apply` or `file-state`, passing in sops encrypted secret file:
 ```shell script
 vault-auto-config file-state --input-dir <config dir> --secrets secrets.yaml
+```
+
+Or passing in a plaintext values file for the same purpose
+```shell script
+vault-auto-config file-state --input-dir <config dir> --additional-values secrets.yaml.dec
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ vault-auto-config file-state --input-dir <config dir> --secrets secrets.yaml
 
 Or passing in a plaintext values file for the same purpose
 ```shell script
-vault-auto-config file-state --input-dir <config dir> --additional-values secrets.yaml.dec
+vault-auto-config file-state --input-dir <config dir> --values secrets.yaml.dec
 ```
 
 

--- a/cmd/vault-auto-config/cmd/apply.go
+++ b/cmd/vault-auto-config/cmd/apply.go
@@ -15,7 +15,7 @@ var (
 		Long:  "Applies the given vault configuration from the specified directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			vaultAutoConfig := pkg.NewVaultAutoConfig()
-			return vaultAutoConfig.Apply(url, token, inputDir, secrets)
+			return vaultAutoConfig.Apply(url, token, inputDir, secrets, additionalValues)
 		},
 	}
 )
@@ -31,4 +31,5 @@ func init() {
 	_ = applyCmd.MarkFlagRequired("input-dir")
 	addVaultFlags(applyCmd)
 	addSecretsFlag(applyCmd)
+	addValuesFlag(applyCmd)
 }

--- a/cmd/vault-auto-config/cmd/apply.go
+++ b/cmd/vault-auto-config/cmd/apply.go
@@ -15,7 +15,7 @@ var (
 		Long:  "Applies the given vault configuration from the specified directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			vaultAutoConfig := pkg.NewVaultAutoConfig()
-			return vaultAutoConfig.Apply(url, token, inputDir, secrets, additionalValues)
+			return vaultAutoConfig.Apply(url, token, inputDir, secrets, values)
 		},
 	}
 )

--- a/cmd/vault-auto-config/cmd/file-state.go
+++ b/cmd/vault-auto-config/cmd/file-state.go
@@ -29,4 +29,5 @@ func init() {
 	)
 	_ = fileStateCmd.MarkFlagRequired("input-dir")
 	addSecretsFlag(fileStateCmd)
+	addValuesFlag(applyCmd
 }

--- a/cmd/vault-auto-config/cmd/file-state.go
+++ b/cmd/vault-auto-config/cmd/file-state.go
@@ -13,7 +13,7 @@ var (
 		Long:  "Returns the current vault configuration state from the file system",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			vaultAutoConfig := pkg.NewVaultAutoConfig()
-			fmt.Println(vaultAutoConfig.FileState(inputDir, secrets))
+			fmt.Println(vaultAutoConfig.FileState(inputDir, secrets, values))
 			return nil
 		},
 	}
@@ -29,5 +29,5 @@ func init() {
 	)
 	_ = fileStateCmd.MarkFlagRequired("input-dir")
 	addSecretsFlag(fileStateCmd)
-	addValuesFlag(applyCmd
+	addValuesFlag(fileStateCmd)
 }

--- a/cmd/vault-auto-config/cmd/root.go
+++ b/cmd/vault-auto-config/cmd/root.go
@@ -11,6 +11,7 @@ var (
 	token   string
 	verbose bool
 	secrets string
+	additionalValues string
 
 	rootCmd = &cobra.Command{
 		Use:   "vault-auto-config",
@@ -71,5 +72,14 @@ func addSecretsFlag(cmd *cobra.Command) {
 		"s",
 		"",
 		"A secrets yaml file encrypted with sops to pass in for go template values",
+	)
+}
+func addValuesFlag(cmd *combra.Command) {
+	cmd.Flags().StringVarP(
+		&additionalValues,
+		"additional-values",
+		"a",
+		"",
+		"A plaintext yaml file to template from",
 	)
 }

--- a/cmd/vault-auto-config/cmd/root.go
+++ b/cmd/vault-auto-config/cmd/root.go
@@ -11,7 +11,7 @@ var (
 	token   string
 	verbose bool
 	secrets string
-	additionalValues string
+	values string
 
 	rootCmd = &cobra.Command{
 		Use:   "vault-auto-config",
@@ -74,10 +74,10 @@ func addSecretsFlag(cmd *cobra.Command) {
 		"A secrets yaml file encrypted with sops to pass in for go template values",
 	)
 }
-func addValuesFlag(cmd *combra.Command) {
+func addValuesFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
-		&additionalValues,
-		"additional-values",
+		&values,
+		"values",
 		"a",
 		"",
 		"A plaintext yaml file to template from",

--- a/pkg/vault-auto-config/client/client_filesystem.go
+++ b/pkg/vault-auto-config/client/client_filesystem.go
@@ -61,8 +61,6 @@ func NewFileSystemClient(dir string, secretsFile string, valuesFile string) (*Fi
 		}
 	}
 
-	fmt.Println(secrets)
-
 	return &FileSystemClient{dir: dir, secrets: secrets}, nil
 }
 

--- a/pkg/vault-auto-config/vault_auto_config.go
+++ b/pkg/vault-auto-config/vault_auto_config.go
@@ -37,7 +37,7 @@ func (c *VaultAutoConfig) Dump(url string, token string, outputDir string, force
 		return err
 	}
 
-	file, err := client.NewFileSystemClient(outputDir, "")
+	file, err := client.NewFileSystemClient(outputDir, "", "")
 	if err != nil {
 		return err
 	}
@@ -51,14 +51,14 @@ func (c *VaultAutoConfig) Dump(url string, token string, outputDir string, force
 	return state.ApplyState(config, file)
 }
 
-// Applies vault configuration from a directory, optionally, with a secrets file to decrypt using sops
-func (c *VaultAutoConfig) Apply(url string, token string, inputDir string, secrets string) error {
+// Applies vault configuration from a directory, optionally, with a file of values and/or a secrets file to decrypt using sops
+func (c *VaultAutoConfig) Apply(url string, token string, inputDir string, secrets string, values string) error {
 	vault, err := client.NewVaultClient(url, token)
 	if err != nil {
 		return err
 	}
 
-	file, err := client.NewFileSystemClient(inputDir, secrets)
+	file, err := client.NewFileSystemClient(inputDir, secrets, values)
 	if err != nil {
 		return err
 	}
@@ -72,8 +72,8 @@ func (c *VaultAutoConfig) Apply(url string, token string, inputDir string, secre
 	return state.ApplyState(config, vault)
 }
 
-func (c *VaultAutoConfig) FileState(inputDir string, secrets string) (string, error) {
-	client, err := client.NewFileSystemClient(inputDir, secrets)
+func (c *VaultAutoConfig) FileState(inputDir string, secrets string, values string) (string, error) {
+	client, err := client.NewFileSystemClient(inputDir, secrets, values)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This adds the flag `--values` for `apply` and `file-state`. Right now, we can template values and populate them with `--secret` but it inherently only supports a SOPS encrypted file. This let's you add an unencrypted file that will also be used for templating. This let's you manage the encryption outside of `vault-auto-config` (to use other encryption tools)