### PR TITLE
Remove docker build/push during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,20 +34,6 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
-  build_push_docker:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
-    needs: get_version
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.ARTIFACTORY_DEPLOY_USER }}
-          password: ${{ secrets.ARTIFACTORY_DEPLOY_PASSWORD }}
-          registry: artifactory.rtr.cloud
-          repository: docker/vault-auto-config
-          tags: latest,${{ needs.get_version.outputs.version }}
-
   upload_assets:
     name: Build and Upload Release Assets
     runs-on: ubuntu-latest


### PR DESCRIPTION
This can be added back to push to dockerhub at a later point, but not necessary to push elsewhere right now. This is broken anyway since public repos do not have access to private org secrets.